### PR TITLE
Remove padding and max-width restriction 👀

### DIFF
--- a/src/Lekplats/styles.scss
+++ b/src/Lekplats/styles.scss
@@ -72,9 +72,7 @@
 
 .component {
   width: 100%;
-  max-width: 700px;
   box-sizing: border-box;
-  padding: 20px;
   position: relative;
 
   iframe {


### PR DESCRIPTION
- The padding can be misleading when testing components;
- The width restriction can be setup using the device simulator.