### PR TITLE
Apply styles only to Lekplats's own iframe

### DIFF
--- a/src/Lekplats/styles.scss
+++ b/src/Lekplats/styles.scss
@@ -75,7 +75,7 @@
   box-sizing: border-box;
   position: relative;
 
-  iframe {
+  & > iframe {
     width: 100%;
     height: 100%;
     border: 0;


### PR DESCRIPTION
This fix stops Lekplats's iframe styles from being incorrectly applied also to iframes within the component rendered in the playground.